### PR TITLE
refactor: 把status页面的agent-metrics拆分成一个个独立的请求

### DIFF
--- a/backend/src/services/StatusService.ts
+++ b/backend/src/services/StatusService.ts
@@ -240,23 +240,13 @@ export async function getStatusPagePublicData(env: { DB: Bindings["DB"] }) {
     }
   }
 
-  // 获取客户端详细信息
+  // 获取客户端基本信息
   let agents: Agent[] = [];
   if (selectedAgents.results && selectedAgents.results.length > 0) {
     const agentIds = selectedAgents.results.map((a) => a.agent_id);
 
     if (agentIds.length > 0) {
       const agentsResult = await repositories.getAgentsByIds(env.DB, agentIds);
-      const agentsMetricsResult =
-        await repositories.getAgentMetricsByIds(env.DB, agentIds);
-      if (agentsMetricsResult.results) {
-        for (const agent of agentsResult.results || []) {
-          const agentMetrics = agentsMetricsResult.results.filter(
-            (m) => m.agent_id === agent.id
-          );
-          agent.metrics = agentMetrics;
-        }
-      }
 
       if (agentsResult.results) {
         agents = agentsResult.results;

--- a/frontend/src/pages/status/StatusPage.tsx
+++ b/frontend/src/pages/status/StatusPage.tsx
@@ -5,6 +5,7 @@ import AgentCard from "../../components/AgentCard";
 import MonitorCard from "../../components/MonitorCard";
 import { useTranslation } from "react-i18next";
 import { Agent, MonitorWithDailyStatsAndStatusHistory } from "../../types";
+import { getAgentMetrics } from "../../api";
 
 const StatusPage = () => {
   const { t } = useTranslation();
@@ -47,6 +48,15 @@ const StatusPage = () => {
       setPageDescription(
         response.description || t("statusPage.allOperational")
       );
+      if (response.agents) {
+        // 获取每个代理的指标数据
+        await Promise.all(
+          response.agents.map(async (agent) => {
+            const metrics = await getAgentMetrics(agent.id);
+            agent.metrics = metrics.agent || [];
+          })
+        );
+      }
       console.log(response);
       setData({
         monitors: response.monitors || [],


### PR DESCRIPTION
上一个PR没有来得及改status页面，现在补上
这回本地测试了一下

![image](https://github.com/user-attachments/assets/2c8ff1a3-1503-458d-84f5-d5f46a3294d1)

没有拆分 获取所有api监控信息 的相关代码。我看了一下两个api监控才几kb，对比动则100kb的agent小了不少，就没管他了。
之前提到的SSR我个人没什么思路，估计得大佬你有空再来改了