### PR TITLE
feat: 尝试适配PWA，添加ServiceWorker sw.js支持，更新manifest文件名称

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>XUGOU - 轻量化监控平台</title>
   </head>

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -29,10 +29,6 @@
   "lang": "zh",
   "scope": "/",
   "orientation": "portrait",
-  "display_override": [
-    "standalone",
-    "window-controls-overlay"
-  ],
   "iarc_rating_id": "e58c174a-81d2-5c3c-32cc-34b8de4a52e9",
   "prefer_related_applications": false
 }

--- a/frontend/public/sw.js
+++ b/frontend/public/sw.js
@@ -1,0 +1,11 @@
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(fetch(event.request));
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,19 @@ import "./styles/index.css";
 import "./locales/config";
 import router from "./router";
 
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/sw.js")
+      .then((registration) => {
+        console.log("Service Worker 注册成功:", registration);
+      })
+      .catch((registrationError) => {
+        console.log("Service Worker 注册失败:", registrationError);
+      });
+  });
+}
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <AuthProvider>


### PR DESCRIPTION
我看到项目里有一些PWA的mainfest文件，刚好我最近在做一个PWA项目，就尝试给xugou适配一下PWA，没想到可以了

[CF Pages预览部署](https://feat-pwa.xugou-d3t.pages.dev/)

然后是手机上的用edge浏览器安装的运行截图（我这个手机好像有点bug，有时候顶栏有一部分挡住了，linux.do的PWA应用也是一样）

<img src="https://github.com/user-attachments/assets/33f8213c-cba6-48ee-8d50-d56b255a4da7" width="200"/>
<img src="https://github.com/user-attachments/assets/dc405f09-8bc2-48d7-a96e-19653a090646" width="200"/>
<img src="https://github.com/user-attachments/assets/8f50bb00-1a1f-46ef-b1fd-33f576a609fa" width="200"/>
